### PR TITLE
coq_makefile2: Better error handling of failed *.v.d files

### DIFF
--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -484,7 +484,7 @@ $(filter-out $(MLLIBFILES:.mllib=.cmxs) $(MLPACKFILES:.mlpack=.cmxs) $(addsuffix
 	$(SHOW)'[deprecated,use-mllib-or-mlpack] CAMLOPT -shared -o $@'
 	$(HIDE)$(CAMLOPTLINK) $(CAMLDEBUG) $(CAMLFLAGS) -shared -o $@ $<
 
-$(VOFILES): %.vo: %.v
+$(VOFILES): %.vo: %.v | %.v.d
 	$(SHOW)COQC $<
 	$(HIDE)$(COQC) $(COQDEBUG) $(COQFLAGS) $<
 
@@ -492,7 +492,7 @@ $(VOFILES): %.vo: %.v
 $(GLOBFILES): %.glob: %.v
 	$(COQC) $(COQDEBUG) $(COQFLAGS) $<
 
-$(VFILES:.v=.vio): %.vio: %.v
+$(VFILES:.v=.vio): %.vio: %.v | %.v.d
 	$(SHOW)COQC -quick $<
 	$(HIDE)$(COQC) -quick $(COQDEBUG) $(COQFLAGS) $<
 
@@ -523,10 +523,10 @@ $(GHTMLFILES): %.g.html: %.v %.glob
 # Dependency files ############################################################
 
 ifneq ($(filter-out archclean clean cleanall printenv,$(MAKECMDGOALS)),)
- include $(ALLDFILES)
+ -include $(ALLDFILES)
 else
  ifeq ($(MAKECMDGOALS),)
-  include $(ALLDFILES)
+  -include $(ALLDFILES)
  endif
 endif
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -484,7 +484,7 @@ $(filter-out $(MLLIBFILES:.mllib=.cmxs) $(MLPACKFILES:.mlpack=.cmxs) $(addsuffix
 	$(SHOW)'[deprecated,use-mllib-or-mlpack] CAMLOPT -shared -o $@'
 	$(HIDE)$(CAMLOPTLINK) $(CAMLDEBUG) $(CAMLFLAGS) -shared -o $@ $<
 
-$(VOFILES): %.vo: %.v | %.v.d
+$(VOFILES): %.vo: %.v
 	$(SHOW)COQC $<
 	$(HIDE)$(COQC) $(COQDEBUG) $(COQFLAGS) $<
 
@@ -492,7 +492,7 @@ $(VOFILES): %.vo: %.v | %.v.d
 $(GLOBFILES): %.glob: %.v
 	$(COQC) $(COQDEBUG) $(COQFLAGS) $<
 
-$(VFILES:.v=.vio): %.vio: %.v | %.v.d
+$(VFILES:.v=.vio): %.vio: %.v
 	$(SHOW)COQC -quick $<
 	$(HIDE)$(COQC) -quick $(COQDEBUG) $(COQFLAGS) $<
 


### PR DESCRIPTION
Now we only error on failure to create *.v.d files if we are trying to build a .vo or .vio target (which are the only rules that *.v.d files add), and we don't spew warnings about not-yet-created *.v.d files.  Incidentally, this should fix the Bedrock ci.